### PR TITLE
README: add Curify AI link in About-the-author + production-AI blog r…

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Readers will be equipped to design, implement, and evaluate LLM-powered recommen
 
 **Jianqiang (Jay) Wang** is a seasoned data science professional with a Ph.D. in Statistics and extensive experience across academia and industry. Formerly a Principal Applied Science Manager at Microsoft, Jay has also served as Visiting Professor at Colorado State University, Data Scientist at Twitter, Lead Data Scientist at Snap, and Director of Data Science at Kuaishou. His expertise spans backend algorithms for search advertising, customer growth, inventory optimization, and ML education—particularly in internet platforms and retail innovation.
 
-[LinkedIn](https://www.linkedin.com/in/jay-jianqiang-wang-78a6726/) | [MentorCruise](https://mentorcruise.com/mentor/jaywang/) 
+Jay is also the founder of **[Curify AI](https://www.curify-ai.com)**, where many of the production patterns from this book — schema-validated LLM pipelines, embedding-based retrieval, multi-stage workflows — power live video translation, MBTI character cards, bilingual subtitles, and visual-content tools. For a longer write-up on turning probabilistic LLMs into deterministic production systems, see [From Probabilistic to Deterministic: Hard Truths About AI Engineering in Production](https://www.curify-ai.com/blog/ai-engineering-hard-truth).
+
+[LinkedIn](https://www.linkedin.com/in/jay-jianqiang-wang-78a6726/) | [MentorCruise](https://mentorcruise.com/mentor/jaywang/) | [Curify AI](https://www.curify-ai.com)
 
 [Order now from Amazon](https://www.amazon.com/dp/B0FX7N91FQ/ref=tmm_kin_swatch_0)


### PR DESCRIPTION
…eference

Adds a contextual paragraph in the About-the-author section noting the maintainer is also the founder of Curify AI, where the production patterns from the book are used live. Links to the AI-engineering hard- truths blog post which directly extends the books production-AI angle.

Also adds Curify AI to the LinkedIn / MentorCruise link row at the bottom so the maintainer footer is consistent across the public repos.

Backlink rationale: this repo is the public companion to the book (Building Recommender Systems Using Large Language Models, Springer), which is the highest-authority surface in the maintainer linkfarm. Landing the link on the default branch makes it crawlable by Google.